### PR TITLE
fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [Jekyll](https://jekyllrb.com/) plugin creates an `uglify` Liquid Template 
 2. Add this to Jekyll's `_config.yml` file:
 
   ```
-  gems:
+  plugins:
     - uglifier
   ```
 


### PR DESCRIPTION
got this: `Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.` so making the change to the documentation